### PR TITLE
Make `toRaw` return a `NonEmptyList`

### DIFF
--- a/core/src/main/scala/org/http4s/Header.scala
+++ b/core/src/main/scala/org/http4s/Header.scala
@@ -147,10 +147,10 @@ object Header {
 
     /** Transform this header into a [[Header.Raw]]
       */
-    def toRawOne(a: A): Header.Raw
+    def toRaw1(a: A): Header.Raw
 
     /** Transform this (potentially repeating) header into a [[Header.Raw]] */
-    def toRaw(a: F[A]): Header.Raw
+    def toRaw(a: F[A]): NonEmptyList[Header.Raw]
 
     /** Selects this header from a list of [[Header.Raw]]
       */
@@ -162,11 +162,11 @@ object Header {
       new Select[A] {
         type F[B] = NonEmptyList[B]
 
-        def toRawOne(a: A): Header.Raw =
+        def toRaw1(a: A): Header.Raw =
           Header.Raw(h.name, h.value(a))
 
-        def toRaw(a: F[A]): Header.Raw =
-          Header.Raw(h.name, a.map(h.value).mkString_(", "))
+        def toRaw(as: F[A]): NonEmptyList[Header.Raw] =
+          as.map(a => Header.Raw(h.name, h.value(a)))
 
         def from(headers: List[Raw]): Option[Ior[NonEmptyList[ParseFailure], NonEmptyList[A]]] =
           headers.foldLeft(Option.empty[Ior[NonEmptyList[ParseFailure], NonEmptyList[A]]]) {
@@ -189,10 +189,11 @@ object Header {
       new Select[A] {
         type F[B] = B
 
-        def toRawOne(a: A): Header.Raw =
+        def toRaw1(a: A): Header.Raw =
           Header.Raw(h.name, h.value(a))
 
-        def toRaw(a: A): Header.Raw = toRawOne(a)
+        def toRaw(a: A): NonEmptyList[Header.Raw] =
+          NonEmptyList.one(toRaw1(a))
 
         def from(headers: List[Raw]): Option[Ior[NonEmptyList[ParseFailure], F[A]]] =
           headers.collectFirst(Function.unlift(fromRaw(_).map(_.leftMap(NonEmptyList.one))))
@@ -203,10 +204,11 @@ object Header {
       new Select[A] {
         type F[B] = B
 
-        def toRawOne(a: A): Header.Raw =
+        def toRaw1(a: A): Header.Raw =
           Header.Raw(h.name, h.value(a))
 
-        def toRaw(a: F[A]): Header.Raw = toRawOne(a)
+        def toRaw(a: A): NonEmptyList[Header.Raw] =
+          NonEmptyList.one(toRaw1(a))
 
         def from(headers: List[Raw]): Option[Ior[NonEmptyList[ParseFailure], F[A]]] =
           headers.foldLeft(Option.empty[Ior[NonEmptyList[ParseFailure], F[A]]]) { (a, raw) =>

--- a/core/src/main/scala/org/http4s/syntax/HeaderSyntax.scala
+++ b/core/src/main/scala/org/http4s/syntax/HeaderSyntax.scala
@@ -17,6 +17,7 @@
 package org.http4s
 package syntax
 
+import cats.data.NonEmptyList
 import org.http4s.util.Renderer
 import org.typelevel.ci.CIString
 
@@ -38,11 +39,11 @@ final class HeaderOps[A](val a: A, header: Header[A, _]) {
 }
 
 final class SelectOpsOne[A](val a: A)(implicit ev: Header.Select[A]) {
-  def toRaw: Header.Raw = ev.toRawOne(a)
+  def toRaw: Header.Raw = ev.toRaw1(a)
   def renderString: String = Renderer.renderString(a)
 }
 
 final class SelectOpsMultiple[A, H[_]](val a: H[A])(implicit ev: Header.Select.Aux[A, H]) {
-  def toRaw: Header.Raw = ev.toRaw(a)
+  def toRaw: NonEmptyList[Header.Raw] = ev.toRaw(a)
   //def renderString: String = Renderer.renderString(a) //TODO
 }

--- a/core/src/main/scala/org/http4s/util/Renderable.scala
+++ b/core/src/main/scala/org/http4s/util/Renderable.scala
@@ -100,7 +100,7 @@ object Renderer {
 
   implicit def headerSelectRenderer[A](implicit select: Header.Select[A]): Renderer[A] =
     new Renderer[A] {
-      override def render(writer: Writer, t: A): writer.type = writer << select.toRawOne(t)
+      override def render(writer: Writer, t: A): writer.type = writer << select.toRaw1(t)
     }
 }
 


### PR DESCRIPTION
This `toRaw` signature is needed by rho, but it's invalid for multi-value headers that can't be comma-concatenated.  The most prominent of these is `Set-Cookie`.