### PR TITLE
Change toRaw to toRaw1 for consistency

### DIFF
--- a/blaze-server/src/test/scala/org/http4s/blaze/server/Http1ServerStageSpec.scala
+++ b/blaze-server/src/test/scala/org/http4s/blaze/server/Http1ServerStageSpec.scala
@@ -295,7 +295,7 @@ class Http1ServerStageSpec extends Http4sSuite {
         // Both responses must succeed
         assertEquals(
           parseAndDropDate(buff),
-          (Ok, Set(H.`Content-Length`.unsafeFromLong(4).toRaw), "done"))
+          (Ok, Set(H.`Content-Length`.unsafeFromLong(4).toRaw1), "done"))
       }
   }
 
@@ -321,8 +321,8 @@ class Http1ServerStageSpec extends Http4sSuite {
           (
             Ok,
             Set(
-              H.`Content-Length`.unsafeFromLong(8 + 4).toRaw,
-              H.`Content-Type`(MediaType.text.plain, Charset.`UTF-8`).toRaw
+              H.`Content-Length`.unsafeFromLong(8 + 4).toRaw1,
+              H.`Content-Type`(MediaType.text.plain, Charset.`UTF-8`).toRaw1
             ),
             "Result: done")
         )
@@ -344,8 +344,8 @@ class Http1ServerStageSpec extends Http4sSuite {
 
       (runRequest(tw, Seq(req1, req2), routes).result).map { buff =>
         val hs = Set(
-          H.`Content-Type`(MediaType.text.plain, Charset.`UTF-8`).toRaw,
-          H.`Content-Length`.unsafeFromLong(3).toRaw
+          H.`Content-Type`(MediaType.text.plain, Charset.`UTF-8`).toRaw1,
+          H.`Content-Length`.unsafeFromLong(3).toRaw1
         )
         // Both responses must succeed
         assertEquals(dropDate(ResponseParser.parseBuffer(buff)), (Ok, hs, "foo"))
@@ -370,8 +370,8 @@ class Http1ServerStageSpec extends Http4sSuite {
 
       (runRequest(tw, Seq(r11, r12, req2), routes).result).map { buff =>
         val hs = Set(
-          H.`Content-Type`(MediaType.text.plain, Charset.`UTF-8`).toRaw,
-          H.`Content-Length`.unsafeFromLong(3).toRaw
+          H.`Content-Type`(MediaType.text.plain, Charset.`UTF-8`).toRaw1,
+          H.`Content-Length`.unsafeFromLong(3).toRaw1
         )
         // Both responses must succeed
         assertEquals(dropDate(ResponseParser.parseBuffer(buff)), (Ok, hs, "foo"))
@@ -395,8 +395,8 @@ class Http1ServerStageSpec extends Http4sSuite {
 
       (runRequest(tw, Seq(r11, r12, req2), routes).result).map { buff =>
         val hs = Set(
-          H.`Content-Type`(MediaType.text.plain, Charset.`UTF-8`).toRaw,
-          H.`Content-Length`.unsafeFromLong(3).toRaw
+          H.`Content-Type`(MediaType.text.plain, Charset.`UTF-8`).toRaw1,
+          H.`Content-Length`.unsafeFromLong(3).toRaw1
         )
         // Both responses must succeed
         assertEquals(dropDate(ResponseParser.parseBuffer(buff)), (Ok, hs, "foo"))
@@ -421,11 +421,11 @@ class Http1ServerStageSpec extends Http4sSuite {
         // Both responses must succeed
         assertEquals(
           dropDate(ResponseParser.parseBuffer(buff)),
-          (Ok, Set(H.`Content-Length`.unsafeFromLong(4).toRaw), "done")
+          (Ok, Set(H.`Content-Length`.unsafeFromLong(4).toRaw1), "done")
         )
         assertEquals(
           dropDate(ResponseParser.parseBuffer(buff)),
-          (Ok, Set(H.`Content-Length`.unsafeFromLong(5).toRaw), "total"))
+          (Ok, Set(H.`Content-Length`.unsafeFromLong(5).toRaw1), "total"))
       }
   }
 
@@ -445,10 +445,10 @@ class Http1ServerStageSpec extends Http4sSuite {
       // Both responses must succeed
       assertEquals(
         dropDate(ResponseParser.parseBuffer(buff)),
-        (Ok, Set(H.`Content-Length`.unsafeFromLong(4).toRaw), "done"))
+        (Ok, Set(H.`Content-Length`.unsafeFromLong(4).toRaw1), "done"))
       assertEquals(
         dropDate(ResponseParser.parseBuffer(buff)),
-        (Ok, Set(H.`Content-Length`.unsafeFromLong(5).toRaw), "total"))
+        (Ok, Set(H.`Content-Length`.unsafeFromLong(5).toRaw1), "total"))
     }
   }
 

--- a/blaze-server/src/test/scala/org/http4s/blaze/server/ServerTestRoutes.scala
+++ b/blaze-server/src/test/scala/org/http4s/blaze/server/ServerTestRoutes.scala
@@ -28,12 +28,12 @@ import org.typelevel.ci._
 
 object ServerTestRoutes extends Http4sDsl[IO] {
   //TODO: bring back well-typed value once all headers are moved to new model
-  val textPlain = `Content-Type`(MediaType.text.plain, `UTF-8`).toRaw
-  val connClose = Connection(ci"close").toRaw
-  val connKeep = Connection(ci"keep-alive").toRaw
-  val chunked = `Transfer-Encoding`(TransferCoding.chunked).toRaw
+  val textPlain = `Content-Type`(MediaType.text.plain, `UTF-8`).toRaw1
+  val connClose = Connection(ci"close").toRaw1
+  val connKeep = Connection(ci"keep-alive").toRaw1
+  val chunked = `Transfer-Encoding`(TransferCoding.chunked).toRaw1
 
-  def length(l: Long) = `Content-Length`.unsafeFromLong(l).toRaw
+  def length(l: Long) = `Content-Length`.unsafeFromLong(l).toRaw1
   def testRequestResults: Seq[(String, (Status, Set[Header.Raw], String))] =
     Seq(
       ("GET /get HTTP/1.0\r\n\r\n", (Status.Ok, Set(length(3), textPlain), "get")),

--- a/core/src/main/scala/org/http4s/syntax/HeaderSyntax.scala
+++ b/core/src/main/scala/org/http4s/syntax/HeaderSyntax.scala
@@ -39,7 +39,7 @@ final class HeaderOps[A](val a: A, header: Header[A, _]) {
 }
 
 final class SelectOpsOne[A](val a: A)(implicit ev: Header.Select[A]) {
-  def toRaw: Header.Raw = ev.toRaw1(a)
+  def toRaw1: Header.Raw = ev.toRaw1(a)
   def renderString: String = Renderer.renderString(a)
 }
 

--- a/tests/src/test/scala/org/http4s/HeadersSpec.scala
+++ b/tests/src/test/scala/org/http4s/HeadersSpec.scala
@@ -64,7 +64,7 @@ class HeadersSpec extends Http4sSuite {
     val h2 = `Set-Cookie`(ResponseCookie("foo2", "bar2"))
     val hs = Headers(clength) ++ Headers(h1, h2)
     assertEquals(hs.headers.count(_.name == `Set-Cookie`.name), 2)
-    assertEquals(hs.headers.exists(_ == clength.toRaw), true)
+    assertEquals(hs.headers.exists(_ == clength.toRaw1), true)
   }
 
   // TODO this isn't really "raw headers" anymore

--- a/tests/src/test/scala/org/http4s/headers/ForwardedRenderersSuite.scala
+++ b/tests/src/test/scala/org/http4s/headers/ForwardedRenderersSuite.scala
@@ -93,7 +93,7 @@ class ForwardedRenderersSuite extends munit.ScalaCheckSuite with ForwardedArbitr
     val headerInit = Forwarded.name.toString + ": "
 
     forAll { (fwd: Forwarded) =>
-      val rendered = Renderer.renderString(fwd.toRaw)
+      val rendered = Renderer.renderString(fwd.toRaw1)
       assert(rendered.startsWith(headerInit))
 
       assertEquals(Forwarded.parse(rendered.drop(headerInit.length)), Right(fwd))

--- a/tests/src/test/scala/org/http4s/headers/HeaderLaws.scala
+++ b/tests/src/test/scala/org/http4s/headers/HeaderLaws.scala
@@ -36,7 +36,7 @@ trait HeaderLaws extends munit.DisciplineSuite with Laws {
         assertEquals(a.renderString, s"${a.name}: ${a.value}")
       },
       """header matches itself""" -> forAll { (a: A) =>
-        assertEquals(Headers(a.toRaw).get[A].get.asInstanceOf[A], a)
+        assertEquals(Headers(a.toRaw1).get[A].get.asInstanceOf[A], a)
       },
       """header does not match arbitrary name""" -> forAll { (a: A, noise: String) =>
         noise.nonEmpty ==> {

--- a/tests/src/test/scala/org/http4s/parser/SimpleHeadersSpec.scala
+++ b/tests/src/test/scala/org/http4s/parser/SimpleHeadersSpec.scala
@@ -52,7 +52,7 @@ class SimpleHeadersSpec extends Http4sSuite {
       )
     )
 
-    assertEquals(`Access-Control-Allow-Headers`.parse(header.toRaw.value), Right(header))
+    assertEquals(`Access-Control-Allow-Headers`.parse(header.toRaw1.value), Right(header))
 
     val invalidHeaderValue = "(non-token-name), non[&token]name"
     assert(`Access-Control-Allow-Headers`.parse(invalidHeaderValue).isLeft)
@@ -67,7 +67,7 @@ class SimpleHeadersSpec extends Http4sSuite {
         ci"*"
       )
     )
-    assertEquals(`Access-Control-Expose-Headers`.parse(header.toRaw.value), Right(header))
+    assertEquals(`Access-Control-Expose-Headers`.parse(header.toRaw1.value), Right(header))
 
     val invalidHeaderValue = "(non-token-name), non[&token]name"
     assert(`Access-Control-Expose-Headers`.parse(invalidHeaderValue).isLeft)
@@ -75,7 +75,7 @@ class SimpleHeadersSpec extends Http4sSuite {
 
   test("parse Connection") {
     val header = Connection(ci"closed")
-    assertEquals(Connection.parse(header.toRaw.value), Right(header))
+    assertEquals(Connection.parse(header.toRaw1.value), Right(header))
   }
 
   test("Parse Content-Length") {
@@ -209,12 +209,12 @@ class SimpleHeadersSpec extends Http4sSuite {
     val header = Server(ProductId("foo", Some("bar")), List(ProductComment("foo")))
     assertEquals(header.value, "foo/bar (foo)")
 
-    assertEquals(Server.parse(header.toRaw.value), Right(header))
+    assertEquals(Server.parse(header.toRaw1.value), Right(header))
 
     val header2 =
       Server(ProductId("foo"), List(ProductId("bar", Some("biz")), ProductComment("blah")))
     assertEquals(header2.value, "foo bar/biz (blah)")
-    assertEquals(Server.parse(header2.toRaw.value), Right(header2))
+    assertEquals(Server.parse(header2.toRaw1.value), Right(header2))
 
     val headerstr = "nginx/1.14.0 (Ubuntu)"
     assertEquals(
@@ -245,16 +245,16 @@ class SimpleHeadersSpec extends Http4sSuite {
   test("SimpleHeaders should parse X-Forwarded-For") {
     // ipv4
     val header2 = `X-Forwarded-For`(NonEmptyList.of(Some(ipv4"127.0.0.1")))
-    assertEquals(`X-Forwarded-For`.parse(header2.toRaw.value), Right(header2))
+    assertEquals(`X-Forwarded-For`.parse(header2.toRaw1.value), Right(header2))
 
     // ipv6
     val header3 = `X-Forwarded-For`(
       NonEmptyList.of(Some(ipv6"::1"), Some(ipv6"2001:0db8:85a3:0000:0000:8a2e:0370:7334")))
-    assertEquals(`X-Forwarded-For`.parse(header3.toRaw.value), Right(header3))
+    assertEquals(`X-Forwarded-For`.parse(header3.toRaw1.value), Right(header3))
 
     // "unknown"
     val header4 = `X-Forwarded-For`(NonEmptyList.of(None))
-    assertEquals(`X-Forwarded-For`.parse(header4.toRaw.value), Right(header4))
+    assertEquals(`X-Forwarded-For`.parse(header4.toRaw1.value), Right(header4))
 
     val bad = "foo"
     assert(`X-Forwarded-For`.parse(bad).isLeft)


### PR DESCRIPTION
I think the syntax needs to be consistent with the typeclass.  This is worth the breaking change.